### PR TITLE
Implement public API for custom placeholders and indicators

### DIFF
--- a/src/main/java/org/teenkung123/damageindicator/DamageIndicator.java
+++ b/src/main/java/org/teenkung123/damageindicator/DamageIndicator.java
@@ -15,12 +15,16 @@ import org.teenkung123.damageindicator.Events.VanillaEvent;
 import org.teenkung123.damageindicator.Loader.ConfigLoader;
 import org.teenkung123.damageindicator.Utils.HealthBarBatchUpdater;
 import org.teenkung123.damageindicator.Utils.HoloDisplays;
+import org.teenkung123.damageindicator.api.DamageIndicatorAPI;
+import org.teenkung123.damageindicator.manager.PlaceholderManager;
 
 public final class DamageIndicator extends JavaPlugin {
 
     private ConfigLoader configLoader;
     private HoloDisplays holoDisplays;
     private HealthBarBatchUpdater healthBarBatchUpdater;
+    private PlaceholderManager placeholderManager;
+    private DamageIndicatorAPI api;
     private boolean usePlaceholderAPI;
     private boolean useMythicMobs;
     private boolean useMyPet;
@@ -37,6 +41,8 @@ public final class DamageIndicator extends JavaPlugin {
         usePlaceholderAPI = Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI");
         useMythicMobs = Bukkit.getPluginManager().isPluginEnabled("MythicMobs");
         useMyPet = Bukkit.getPluginManager().isPluginEnabled("MyPet");
+        placeholderManager = new PlaceholderManager();
+        api = new DamageIndicatorAPI(this);
         HologramLib.getManager().ifPresentOrElse(
                 manager -> hologramManager = manager,
                 () -> getLogger().severe("Failed to initialize HologramLib manager.")
@@ -68,6 +74,8 @@ public final class DamageIndicator extends JavaPlugin {
     public boolean getUseMythicMobs() { return useMythicMobs; }
     public MythicBukkit getMythicBukkit() { return mythicBukkit; }
     public HealthBarBatchUpdater getHealthBarBatchUpdater() { return healthBarBatchUpdater; }
+    public PlaceholderManager getPlaceholderManager() { return placeholderManager; }
+    public DamageIndicatorAPI getApi() { return api; }
 
     public HologramManager getHologramManager() {
         return hologramManager;
@@ -77,7 +85,7 @@ public final class DamageIndicator extends JavaPlugin {
         if (healthBarBatchUpdater != null) healthBarBatchUpdater.stopBatchUpdating();
         this.reloadConfig();
         configLoader = new ConfigLoader(this);
-        holoDisplays = new HoloDisplays(this);
+        holoDisplays = new HoloDisplays(this, placeholderManager);
         healthBarBatchUpdater = new HealthBarBatchUpdater(this, configLoader, holoDisplays);
         if (useMythicMobs) {
             mythicBukkit = MythicBukkit.inst();

--- a/src/main/java/org/teenkung123/damageindicator/api/DamageIndicatorAPI.java
+++ b/src/main/java/org/teenkung123/damageindicator/api/DamageIndicatorAPI.java
@@ -1,0 +1,80 @@
+package org.teenkung123.damageindicator.api;
+
+import com.maximde.hologramlib.hologram.HologramManager;
+import org.bukkit.entity.LivingEntity;
+import org.teenkung123.damageindicator.DamageIndicator;
+import org.teenkung123.damageindicator.Utils.HoloDisplays;
+import org.teenkung123.damageindicator.manager.PlaceholderManager;
+
+import java.util.function.Function;
+
+/**
+ * Public API access point for the DamageIndicator plugin.
+ */
+public class DamageIndicatorAPI {
+
+    private static DamageIndicatorAPI instance;
+    private final DamageIndicator plugin;
+
+    public DamageIndicatorAPI(DamageIndicator plugin) {
+        this.plugin = plugin;
+        instance = this;
+    }
+
+    /**
+     * Returns the API instance.
+     */
+    public static DamageIndicatorAPI getInstance() {
+        return instance;
+    }
+
+    /**
+     * Registers a placeholder for health bar holograms.
+     *
+     * @param key      placeholder key without angle brackets
+     * @param function function to compute the replacement text
+     */
+    public void registerPlaceholder(String key, Function<LivingEntity, String> function) {
+        plugin.getPlaceholderManager().registerPlaceholder(key, function);
+    }
+
+    /**
+     * Unregisters a placeholder.
+     *
+     * @param key placeholder key without angle brackets
+     */
+    public void unregisterPlaceholder(String key) {
+        plugin.getPlaceholderManager().unregisterPlaceholder(key);
+    }
+
+    /**
+     * Displays a custom damage indicator at the given entity.
+     *
+     * @param entity target entity
+     * @param text   text to display
+     */
+    public void displayDamageIndicator(LivingEntity entity, String text) {
+        plugin.getHoloDisplays().displayCustomIndicator(entity, text);
+    }
+
+    /**
+     * Access to the plugin's hologram manager.
+     */
+    public HologramManager getHologramManager() {
+        return plugin.getHologramManager();
+    }
+
+    /**
+     * Access to the HoloDisplays manager.
+     */
+    public HoloDisplays getHoloDisplays() {
+        return plugin.getHoloDisplays();
+    }
+
+    /**
+     * Access to the placeholder manager.
+     */
+    public PlaceholderManager getPlaceholderManager() {
+        return plugin.getPlaceholderManager();
+    }
+}

--- a/src/main/java/org/teenkung123/damageindicator/manager/PlaceholderManager.java
+++ b/src/main/java/org/teenkung123/damageindicator/manager/PlaceholderManager.java
@@ -1,0 +1,60 @@
+package org.teenkung123.damageindicator.manager;
+
+import org.bukkit.entity.LivingEntity;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+/**
+ * Handles custom placeholders for health bar holograms.
+ */
+public class PlaceholderManager {
+
+    private final Map<String, Function<LivingEntity, String>> placeholders = new ConcurrentHashMap<>();
+
+    /**
+     * Registers a placeholder.
+     *
+     * @param key placeholder key without angle brackets
+     * @param function function to compute the replacement text
+     */
+    public void registerPlaceholder(String key, Function<LivingEntity, String> function) {
+        placeholders.put(format(key), function);
+    }
+
+    /**
+     * Unregisters a placeholder.
+     *
+     * @param key placeholder key without angle brackets
+     */
+    public void unregisterPlaceholder(String key) {
+        placeholders.remove(format(key));
+    }
+
+    private String format(String key) {
+        String result = key;
+        if (!result.startsWith("<")) {
+            result = "<" + result;
+        }
+        if (!result.endsWith(">")) {
+            result = result + ">";
+        }
+        return result;
+    }
+
+    /**
+     * Applies all registered placeholders to the given text.
+     *
+     * @param text text containing placeholders
+     * @param entity entity context
+     * @return processed text
+     */
+    public String applyPlaceholders(String text, LivingEntity entity) {
+        String result = text;
+        for (Map.Entry<String, Function<LivingEntity, String>> e : placeholders.entrySet()) {
+            result = result.replace(e.getKey(), e.getValue().apply(entity));
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary
- expose a new `DamageIndicatorAPI` for other plugins
- add `PlaceholderManager` to manage extra placeholders
- extend `HoloDisplays` with custom indicator support and placeholder application
- integrate the API and manager into the main plugin class

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_68814cc2cac883248471a613392dccb0